### PR TITLE
fix(sound): Tempest now uses its own SoundEvents

### DIFF
--- a/src/generated/resources/.cache/735031f3addf80804addae5e3f53249900116f1e
+++ b/src/generated/resources/.cache/735031f3addf80804addae5e3f53249900116f1e
@@ -1,2 +1,2 @@
-// 1.19.4	2023-06-11T21:27:42.5054919	Sound Definitions
-694b67a4125f1002e0cc0a1893b7651d1401adbf assets/aether_genesis/sounds.json
+// 1.19.4	2023-06-14T13:51:58.773454	Sound Definitions
+0beea3443804c62cffed0a4793c5ef69360afc7e assets/aether_genesis/sounds.json

--- a/src/generated/resources/.cache/c622617f6fabf890a00b9275cd5f643584a8a2c8
+++ b/src/generated/resources/.cache/c622617f6fabf890a00b9275cd5f643584a8a2c8
@@ -1,2 +1,2 @@
-// 1.19.4	2023-06-12T16:35:16.7809899	Languages: en_us
-aa041cb994a79cd076618fc73860f070ef057145 assets/aether_genesis/lang/en_us.json
+// 1.19.4	2023-06-14T13:51:58.7704525	Languages: en_us
+22bfff487f3b1030765aa1cfd3e263a9fac8b600 assets/aether_genesis/lang/en_us.json

--- a/src/generated/resources/assets/aether_genesis/lang/en_us.json
+++ b/src/generated/resources/assets/aether_genesis/lang/en_us.json
@@ -88,5 +88,9 @@
   "pack.aether_genesis.mod.description": "The Aether: Genesis Resources",
   "subtitles.aether_genesis.block.aercloud.blue_aercloud_bounce": "Blue Aercloud bounces",
   "subtitles.aether_genesis.entity.carrion_sprout.death": "Carrion Sprout dies",
-  "subtitles.aether_genesis.entity.carrion_sprout.hurt": "Carrion Sprout hurts"
+  "subtitles.aether_genesis.entity.carrion_sprout.hurt": "Carrion Sprout hurts",
+  "subtitles.aether_genesis.entity.tempest.ambient": "Tempest blows",
+  "subtitles.aether_genesis.entity.tempest.death": "Tempest dies",
+  "subtitles.aether_genesis.entity.tempest.hurt": "Tempest hurts",
+  "subtitles.aether_genesis.entity.tempest.shoot": "Tempest spits"
 }

--- a/src/generated/resources/assets/aether_genesis/sounds.json
+++ b/src/generated/resources/assets/aether_genesis/sounds.json
@@ -43,6 +43,30 @@
     ],
     "subtitle": "subtitles.aether_genesis.entity.sentry_guardian.spawn"
   },
+  "entity.tempest.ambient": {
+    "sounds": [
+      "aether:entity/zephyr/call"
+    ],
+    "subtitle": "subtitles.aether_genesis.entity.tempest.ambient"
+  },
+  "entity.tempest.death": {
+    "sounds": [
+      "aether:entity/zephyr/call"
+    ],
+    "subtitle": "subtitles.aether_genesis.entity.tempest.death"
+  },
+  "entity.tempest.hurt": {
+    "sounds": [
+      "aether:entity/zephyr/call"
+    ],
+    "subtitle": "subtitles.aether_genesis.entity.tempest.hurt"
+  },
+  "entity.tempest.shoot": {
+    "sounds": [
+      "aether:entity/zephyr/shoot"
+    ],
+    "subtitle": "subtitles.aether_genesis.entity.tempest.shoot"
+  },
   "entity.tracking_golem.creepy_seen": {
     "sounds": [
       "aether_genesis:entity/tracking_golem/creepy_seen"

--- a/src/main/java/com/aetherteam/aether_genesis/client/GenesisSoundEvents.java
+++ b/src/main/java/com/aetherteam/aether_genesis/client/GenesisSoundEvents.java
@@ -24,6 +24,13 @@ public class GenesisSoundEvents {
     public static final RegistryObject<SoundEvent> ENTITY_SENTRY_GUARDIAN_HIT = register("entity.sentry_guardian.hit");
     public static final RegistryObject<SoundEvent> ENTITY_SENTRY_GUARDIAN_LIVING = register("entity.sentry_guardian.living");
 
+    public static final RegistryObject<SoundEvent> ENTITY_TEMPEST_AMBIENT = register("entity.tempest.ambient");
+    public static final RegistryObject<SoundEvent> ENTITY_TEMPEST_HURT = register("entity.tempest.hurt");
+    public static final RegistryObject<SoundEvent> ENTITY_TEMPEST_DEATH = register("entity.tempest.death");
+    public static final RegistryObject<SoundEvent> ENTITY_TEMPEST_SHOOT = register("entity.tempest.shoot");
+
+
+
     public static final RegistryObject<SoundEvent> ITEM_MUSIC_DISC_AERWHALE = register("item.music_disc.aerwhale");
     public static final RegistryObject<SoundEvent> ITEM_MUSIC_DISC_APPROACHES = register("item.music_disc.approaches");
     public static final RegistryObject<SoundEvent> ITEM_MUSIC_DISC_DEMISE = register("item.music_disc.demise");

--- a/src/main/java/com/aetherteam/aether_genesis/data/generators/GenesisLanguageData.java
+++ b/src/main/java/com/aetherteam/aether_genesis/data/generators/GenesisLanguageData.java
@@ -111,6 +111,10 @@ public class GenesisLanguageData extends GenesisLanguageProvider {
         this.addSubtitle("entity", "carrion_sprout.hurt", "Carrion Sprout hurts");
         this.addSubtitle("entity", "carrion_sprout.death", "Carrion Sprout dies");
         this.addSubtitle("block", "aercloud.blue_aercloud_bounce", "Blue Aercloud bounces");
+        this.addSubtitle("entity", "tempest.shoot", "Tempest spits");
+        this.addSubtitle("entity", "tempest.ambient", "Tempest blows");
+        this.addSubtitle("entity", "tempest.death", "Tempest dies");
+        this.addSubtitle("entity", "tempest.hurt", "Tempest hurts");
         
         this.addContainerType(GenesisMenuTypes.HOLYSTONE_FURNACE, "Holystone Furnace");
 

--- a/src/main/java/com/aetherteam/aether_genesis/data/generators/GenesisSoundData.java
+++ b/src/main/java/com/aetherteam/aether_genesis/data/generators/GenesisSoundData.java
@@ -1,5 +1,6 @@
 package com.aetherteam.aether_genesis.data.generators;
 
+import com.aetherteam.aether.client.AetherSoundEvents;
 import com.aetherteam.aether_genesis.Genesis;
 import com.aetherteam.aether_genesis.client.GenesisSoundEvents;
 import net.minecraft.data.PackOutput;
@@ -86,5 +87,21 @@ public class GenesisSoundData extends SoundDefinitionsProvider {
                 definition().with(sound("aether_genesis:entity/sentry_guardian/hit"))
                         .subtitle("subtitles.aether_genesis.entity.sentry_guardian.hit")
         );
+        this.add(GenesisSoundEvents.ENTITY_TEMPEST_SHOOT,
+                definition().with(sound("aether:entity/zephyr/shoot"))
+                        .subtitle("subtitles.aether_genesis.entity.tempest.shoot"));
+        this.add(GenesisSoundEvents.ENTITY_TEMPEST_AMBIENT,
+                definition().with(sound("aether:entity/zephyr/call"))
+                        .subtitle("subtitles.aether_genesis.entity.tempest.ambient")
+        );
+        this.add(GenesisSoundEvents.ENTITY_TEMPEST_DEATH,
+                definition().with(sound("aether:entity/zephyr/call"))
+                        .subtitle("subtitles.aether_genesis.entity.tempest.death")
+        );
+        this.add(GenesisSoundEvents.ENTITY_TEMPEST_HURT,
+                definition().with(sound("aether:entity/zephyr/call"))
+                        .subtitle("subtitles.aether_genesis.entity.tempest.hurt")
+        );
+
     }
 }

--- a/src/main/java/com/aetherteam/aether_genesis/entity/monster/Tempest.java
+++ b/src/main/java/com/aetherteam/aether_genesis/entity/monster/Tempest.java
@@ -2,6 +2,7 @@ package com.aetherteam.aether_genesis.entity.monster;
 
 import com.aetherteam.aether.client.AetherSoundEvents;
 import com.aetherteam.aether.entity.monster.Zephyr;
+import com.aetherteam.aether_genesis.client.GenesisSoundEvents;
 import com.aetherteam.aether_genesis.entity.miscellaneous.TempestThunderBall;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.DustParticleOptions;
@@ -10,8 +11,10 @@ import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.Difficulty;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -84,6 +87,19 @@ public class Tempest extends Zephyr {
         super.tick();
     }
 
+    protected SoundEvent getAmbientSound() {
+        return GenesisSoundEvents.ENTITY_TEMPEST_AMBIENT.get();
+    }
+
+    protected SoundEvent getHurtSound(@Nonnull DamageSource damageSource) {
+        return GenesisSoundEvents.ENTITY_TEMPEST_HURT.get();
+    }
+
+    protected SoundEvent getDeathSound() {
+        return GenesisSoundEvents.ENTITY_TEMPEST_DEATH.get();
+    }
+
+
     static class ThunderballAttackGoal extends Goal {
         private final Tempest parentEntity;
         public int attackTimer;
@@ -134,7 +150,7 @@ public class Tempest extends Zephyr {
                     double accelX = target.getX() - (this.parentEntity.getX() + look.x * 4.0);
                     double accelY = target.getY(0.5) - (0.5 + this.parentEntity.getY(0.5));
                     double accelZ = target.getZ() - (this.parentEntity.getZ() + look.z * 4.0);
-                    this.parentEntity.playSound(AetherSoundEvents.ENTITY_ZEPHYR_SHOOT.get(), 3.0F, (level.random.nextFloat() - level.random.nextFloat()) * 0.2F + 1.0F);
+                    this.parentEntity.playSound(GenesisSoundEvents.ENTITY_TEMPEST_SHOOT.get(), 3.0F, (level.random.nextFloat() - level.random.nextFloat()) * 0.2F + 1.0F);
                     TempestThunderBall thunderBall = new TempestThunderBall(level);
                     thunderBall.setPos(this.parentEntity.getX() + look.x * 4.0, this.parentEntity.getY(0.5) + 0.5, this.parentEntity.getZ() + look.z * 4.0);
                     thunderBall.shoot(accelX, accelY, accelZ, 1.0F, 1.0F);


### PR DESCRIPTION
Previously, the Tempest did not have its own sounds and just reused the Zephyr's sounds, causing it to both not be customizable in resource packs and not have subtitles properly. This pull request fixes that, giving the Tempest its own SoundEvents for its ambient, hurt, death, and shoot sounds.

---

I agree to the Contributor License Agreement (CLA).