### PR TITLE
change(audio, block): Made Blue Aercloud Bounce sound’s pitch more accurate to GoTV

### DIFF
--- a/src/main/java/com/aetherteam/aether_genesis/mixin/mixins/common/BlueAercloudBlockMixin.java
+++ b/src/main/java/com/aetherteam/aether_genesis/mixin/mixins/common/BlueAercloudBlockMixin.java
@@ -19,7 +19,7 @@ public class BlueAercloudBlockMixin {
     private void entityInside(BlockState state, Level level, BlockPos pos, Entity entity, CallbackInfo ci) {
         if (!entity.isShiftKeyDown()) {
             level.playSound((entity instanceof Player player ? player : (Player) null), pos, GenesisSoundEvents.BLUE_AERCLOUD_BOUNCE.get(), SoundSource.BLOCKS, 0.8f,
-                    0.9f + (level.random.nextFloat() * 0.2f));
+                    0.5f + (level.random.nextFloat() * 0.4f));
         }
     }
 }


### PR DESCRIPTION
While testing GoTV, I noticed that the Blue Aercloud sounds were a bit off. This isn't *really* a big issue, but I felt like fixing it anyway lol

NOTE: turn on sound for the videos

Original (GoTV):

https://github.com/The-Aether-Team/The-Aether-Genesis/assets/60141811/7d508a98-ff7e-43a9-a1a9-e8f7b1059fe1

---
Before this pull request (Aether: Genesis):

https://github.com/The-Aether-Team/The-Aether-Genesis/assets/60141811/32d0c1d8-f18a-4c6a-bf94-0ebf46ae39dc

---
After/With this pull request (Aether: Genesis):

https://github.com/The-Aether-Team/The-Aether-Genesis/assets/60141811/5b234cc7-21f2-498f-8cb6-57b6c257f04f

---

I agree to the Contributor License Agreement (CLA).