### PR TITLE
fix(sound, block): Even MORE accurate (and improved to sound more natural) Blue Aercloud bounce sound

### DIFF
--- a/src/main/java/com/aetherteam/aether_genesis/mixin/mixins/common/BlueAercloudBlockMixin.java
+++ b/src/main/java/com/aetherteam/aether_genesis/mixin/mixins/common/BlueAercloudBlockMixin.java
@@ -4,6 +4,7 @@ import com.aetherteam.aether.block.natural.BlueAercloudBlock;
 import com.aetherteam.aether_genesis.client.GenesisSoundEvents;
 import net.minecraft.core.BlockPos;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
@@ -19,7 +20,7 @@ public class BlueAercloudBlockMixin {
     private void entityInside(BlockState state, Level level, BlockPos pos, Entity entity, CallbackInfo ci) {
         if (!entity.isShiftKeyDown()) {
             level.playSound((entity instanceof Player player ? player : (Player) null), pos, GenesisSoundEvents.BLUE_AERCLOUD_BOUNCE.get(), SoundSource.BLOCKS, 0.8f,
-                    level.random.nextFloat());
+                    0.5f + (Mth.square(level.random.nextFloat()) * 0.5f));
         }
     }
 }

--- a/src/main/java/com/aetherteam/aether_genesis/mixin/mixins/common/BlueAercloudBlockMixin.java
+++ b/src/main/java/com/aetherteam/aether_genesis/mixin/mixins/common/BlueAercloudBlockMixin.java
@@ -19,7 +19,7 @@ public class BlueAercloudBlockMixin {
     private void entityInside(BlockState state, Level level, BlockPos pos, Entity entity, CallbackInfo ci) {
         if (!entity.isShiftKeyDown()) {
             level.playSound((entity instanceof Player player ? player : (Player) null), pos, GenesisSoundEvents.BLUE_AERCLOUD_BOUNCE.get(), SoundSource.BLOCKS, 0.8f,
-                    0.5f + (level.random.nextFloat() * 0.4f));
+                    level.random.nextFloat());
         }
     }
 }

--- a/src/main/java/com/aetherteam/aether_genesis/mixin/mixins/common/BlueAercloudBlockMixin.java
+++ b/src/main/java/com/aetherteam/aether_genesis/mixin/mixins/common/BlueAercloudBlockMixin.java
@@ -20,7 +20,7 @@ public class BlueAercloudBlockMixin {
     private void entityInside(BlockState state, Level level, BlockPos pos, Entity entity, CallbackInfo ci) {
         if (!entity.isShiftKeyDown()) {
             level.playSound((entity instanceof Player player ? player : (Player) null), pos, GenesisSoundEvents.BLUE_AERCLOUD_BOUNCE.get(), SoundSource.BLOCKS, 0.8f,
-                    0.5f + ((level.random.nextFloat() * level.random.nextFloat() * level.random.nextFloat()) * 0.5f));
+                    0.5f + (((float)(Math.pow(level.random.nextDouble(), 2.5))) * 0.5f));
         }
     }
 }

--- a/src/main/java/com/aetherteam/aether_genesis/mixin/mixins/common/BlueAercloudBlockMixin.java
+++ b/src/main/java/com/aetherteam/aether_genesis/mixin/mixins/common/BlueAercloudBlockMixin.java
@@ -20,7 +20,7 @@ public class BlueAercloudBlockMixin {
     private void entityInside(BlockState state, Level level, BlockPos pos, Entity entity, CallbackInfo ci) {
         if (!entity.isShiftKeyDown()) {
             level.playSound((entity instanceof Player player ? player : (Player) null), pos, GenesisSoundEvents.BLUE_AERCLOUD_BOUNCE.get(), SoundSource.BLOCKS, 0.8f,
-                    0.5f + (Mth.square(level.random.nextFloat()) * 0.5f));
+                    0.5f + ((level.random.nextFloat() * level.random.nextFloat() * level.random.nextFloat()) * 0.5f));
         }
     }
 }


### PR DESCRIPTION
My previous pull request was just based on me listening closely and trying to replicate the sound of GoTV's aercloud, but this time I realized I could look at GoTV's source code to see the *exact* values used for the aercloud sound's pitch (since it still sounded a bit off).
I modified it a bit, since it was previously just `level.random.nextFloat()` with no changes, so half of the time it would've just been a pitch of 0.5 due to a bug in vanilla Minecraft. I changed it so that it should now have a pitch range of 0.5 to 1.0, with a bias towards 0.5, rather than GoTV's 0.5 50% of the time and from 0.5 to 1.0 the other 50% of the time, for a slightly more natural sound while still remaining similar to GoTV.


In essence, rather than using GoTV's:
`level.random.nextFloat()` (which gave, due to a bug with minecraft's pitch values, 50% of the time 0.5, and the other 50% of the time a number from 0.5 to 1.0)
I did:
`0.5f + (((float)(Math.pow(level.random.nextDouble(), 2.5))) * 0.5f)` (which gives a number from 0.5 to 1.0, with an exponential (power of 2.5) bias towards 0.5 to simulate the 50/50 chance of the GoTV aercloud with a slightly more natural-sounding result)

so that rather this (GoTV):

https://github.com/The-Aether-Team/The-Aether-Genesis/assets/60141811/88a3d5a1-e981-426f-b3c0-3ca37688110a

It sounds like this (this PR):

https://github.com/The-Aether-Team/The-Aether-Genesis/assets/60141811/ecce87d6-96ad-44c0-b88e-2a3a8391420c

---

I agree to the Contributor License Agreement (CLA).
