### PR TITLE
fix: Fixed crashing mixin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,10 +75,12 @@ sourceSets.main.resources {
 dependencies {
     minecraft "net.neoforged:forge:${project.mc_version}-${project.neoforge_version}"
 
-    implementation(annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-common:0.2.0-beta.9"))
-    annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
-    implementation('com.github.llamalad7.mixinextras:mixinextras-forge:0.2.0-beta.9')
+    annotationProcessor "org.spongepowered:mixin:${project.mixin_version}:processor"
 
+    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:${project.mixinextras_version}"))
+    implementation(jarJar("io.github.llamalad7:mixinextras-forge:${project.mixinextras_version}")) {
+        jarJar.ranged(it, "[0.3.5,)")
+    }
     implementation fg.deobf("com.aetherteam.aether:aether:${project.aether_version}")
 //    implementation fg.deobf("local:aether:${project.aether_version}")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,9 +12,10 @@ neoforge_version=47.1.70
 mappings=2023.08.20-1.20.1
 
 # Dependencies
-aether_version=1.20.1-1.0.0-beta.2.2-neoforge
-nitrogen_version=1.20.1-0.3.0-neoforge
-cumulus_version=1.20.1-1.0.0-beta.1-neoforge
+mixinextras_version=0.3.5
+aether_version=1.20.1-1.4.0-neoforge
+nitrogen_version=1.20.1-1.0.7-neoforge
+cumulus_version=1.20.1-1.0.0-neoforge
 curios_version=5.3.5
 aeroblender_version=4789008
 terrablender_version=1.20.1-3.0.0.169

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@ mod_name=The Aether: Genesis
 mod_version=0.0.1
 mc_version=1.20.1
 neoforge_version=47.1.70
+mixin_version=0.8.5
 mappings=2023.08.20-1.20.1
 
 # Dependencies

--- a/src/main/java/com/aetherteam/aether_genesis/mixin/mixins/common/SliderMixin.java
+++ b/src/main/java/com/aetherteam/aether_genesis/mixin/mixins/common/SliderMixin.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(Slider.class)
 public class SliderMixin {
-    @Redirect(method = "hurt", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;sendSystemMessage(Lnet/minecraft/network/chat/Component;)V"))
+    @Redirect(method = "sendInvalidToolMessage", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;sendSystemMessage(Lnet/minecraft/network/chat/Component;)V"))
     public void displayInvalidToolMessage(Player player, Component component) {
         if (GenesisConfig.COMMON.improved_slider_message.get()) {
             ItemStack stack = player.getMainHandItem();

--- a/src/main/java/com/aetherteam/aether_genesis/mixin/mixins/common/SliderMixin.java
+++ b/src/main/java/com/aetherteam/aether_genesis/mixin/mixins/common/SliderMixin.java
@@ -3,6 +3,8 @@ package com.aetherteam.aether_genesis.mixin.mixins.common;
 
 import com.aetherteam.aether.entity.monster.dungeon.boss.Slider;
 import com.aetherteam.aether_genesis.GenesisConfig;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
@@ -15,8 +17,8 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(Slider.class)
 public class SliderMixin {
-    @Redirect(method = "sendInvalidToolMessage", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;sendSystemMessage(Lnet/minecraft/network/chat/Component;)V"))
-    public void displayInvalidToolMessage(Player player, Component component) {
+    @WrapOperation(method = "sendInvalidToolMessage", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;sendSystemMessage(Lnet/minecraft/network/chat/Component;)V"))
+    public void displayInvalidToolMessage(Player player, Component component, Operation<Void> original) {
         if (GenesisConfig.COMMON.improved_slider_message.get()) {
             ItemStack stack = player.getMainHandItem();
             if (stack.getItem() != Blocks.AIR.asItem()) {
@@ -28,7 +30,7 @@ public class SliderMixin {
                 player.sendSystemMessage(Component.translatable("gui.aether_genesis.slider.message.attack.invalid_fist"));
             }
         } else {
-            player.sendSystemMessage(component);
+            original.call(player, component);
         }
     }
 }


### PR DESCRIPTION
Fixes a mixin crash caused by the Aether's 1.4.0 version

---

I agree to the Contributor License Agreement (CLA).